### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "grunt-markdownlint": "latest",
     "grunt-stylelint": "latest",
     "grunt-yamllint": "latest",
-    "stylelint": "latest",
-    "stylelint-config-standard": "latest",
+    "stylelint": "^14.16.1",
+    "stylelint-config-standard": "^28.0.0",
     "time-grunt": "latest"
   }
 }


### PR DESCRIPTION
Set `stylelint` and `stylelint-config-standard` versions, because version 15 of stylelint is not compatible with `grunt-stylelint`.