### PR TITLE
Add refresh timer for re-rendering displayTemplate

### DIFF
--- a/MMM-HomeAssistantDisplay.js
+++ b/MMM-HomeAssistantDisplay.js
@@ -57,7 +57,7 @@ Module.register("MMM-HomeAssistantDisplay", {
 					setInterval(()=> {
 						this.renderTemplates("timeout");
 						this.updateDom();
-					}, section.refreshTimer);
+					}, section.refreshTimer * 1000);
 				}
 			}
 		}

--- a/MMM-HomeAssistantDisplay.js
+++ b/MMM-HomeAssistantDisplay.js
@@ -52,6 +52,13 @@ Module.register("MMM-HomeAssistantDisplay", {
 						entity: section.triggerEntities[entity]
 					});
 				}
+				// Set up a timer to trigger re-rendering outside of any entity state update
+				if (section.triggerTimer) {
+					setInterval(()=> {
+						this.renderTemplates("timeout");
+						this.updateDom();
+					}, section.triggerTimer);
+				}
 			}
 		}
 		this.renderTemplates("foo");

--- a/MMM-HomeAssistantDisplay.js
+++ b/MMM-HomeAssistantDisplay.js
@@ -53,11 +53,11 @@ Module.register("MMM-HomeAssistantDisplay", {
 					});
 				}
 				// Set up a timer to trigger re-rendering outside of any entity state update
-				if (section.triggerTimer) {
+				if (section.refreshTimer) {
 					setInterval(()=> {
 						this.renderTemplates("timeout");
 						this.updateDom();
-					}, section.triggerTimer);
+					}, section.refreshTimer);
 				}
 			}
 		}

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Templates allow you to output virtually any HTML you want to in the contents of 
 | triggerEntities | The array of entities to watch for state changes to determine if this sections displayTemplate should be re-rendered. |
 | displayTemplate | The template to send to Home Assistant to render.  The results of the render will be displayed as the contents of this section in the module. |
 | class | The CSS class name to add to the `<div>` surrounding this section of the module. This is a name you choose yourself, for example "HAValues". You can then style this section by adding a .HAvalues-section in custom.css. |
+| triggerTimer | Set a trigger timeout in milliseconds to re-render this section's displayTemplate, regardless of whether or not an entity has changed states. |
 
 #### Note
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Templates allow you to output virtually any HTML you want to in the contents of 
 | triggerEntities | The array of entities to watch for state changes to determine if this sections displayTemplate should be re-rendered. |
 | displayTemplate | The template to send to Home Assistant to render.  The results of the render will be displayed as the contents of this section in the module. |
 | class | The CSS class name to add to the `<div>` surrounding this section of the module. This is a name you choose yourself, for example "HAValues". You can then style this section by adding a .HAvalues-section in custom.css. |
-| refreshTimer | Set a refresh timeout in milliseconds to re-render this section's displayTemplate, regardless of whether or not an entity has changed states. |
+| refreshTimer | Set a refresh timeout in seconds to re-render this section's displayTemplate, regardless of whether or not an entity has changed states. |
 
 #### Note
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Templates allow you to output virtually any HTML you want to in the contents of 
 | triggerEntities | The array of entities to watch for state changes to determine if this sections displayTemplate should be re-rendered. |
 | displayTemplate | The template to send to Home Assistant to render.  The results of the render will be displayed as the contents of this section in the module. |
 | class | The CSS class name to add to the `<div>` surrounding this section of the module. This is a name you choose yourself, for example "HAValues". You can then style this section by adding a .HAvalues-section in custom.css. |
-| triggerTimer | Set a trigger timeout in milliseconds to re-render this section's displayTemplate, regardless of whether or not an entity has changed states. |
+| refreshTimer | Set a refresh timeout in milliseconds to re-render this section's displayTemplate, regardless of whether or not an entity has changed states. |
 
 #### Note
 


### PR DESCRIPTION
This PR adds a Section configuration option to re-render the displayTemplate every N milliseconds, regardless of whether an entity has changed states or not.

I have one legitimate use case and one hacky use case for this.

The legitimate use case is for the occasion when you want to get a resource from the Home Assistant server that changes over time but does not have an event tied to it. A good example of this is the `entity_picture` state attribute of a `camera` entity that represents a security camera. This picture is almost constantly updating, but the `camera` state does not change with it.

The hacky use case is to bypass issue #21. The timer can act as a fail safe in the case that the module stops updating properly. I don't really like this as a solution, but it's better than nothing.